### PR TITLE
BF: Skip PCA projection and results storing for spike-less groups

### DIFF
--- a/klusta/traces/spikedetekt.py
+++ b/klusta/traces/spikedetekt.py
@@ -653,6 +653,8 @@ class SpikeDetekt(object):
             # self._store.delete(name='components', chunk_key=chunk.key)
             # split: {group: {'spike_samples': ..., 'waveforms':, 'masks':}}
             for group, out in split.items():
+                if pcs[group] is None:
+                    continue
                 out['features'] = self.features(out['waveforms'], pcs[group])
                 # Checking that spikes are increasing.
                 spikes = out['spike_samples']


### PR DESCRIPTION
Pull request re: spikedetekt bug for sparsely spiking channels in phy-users [link](https://groups.google.com/d/msgid/phy-users/5a1445bf-3a49-4d0e-a2ff-57619847784e%40googlegroups.com?utm_medium=email&utm_source=footer)