### PR TITLE
Add missing runtime/install-time dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,16 @@ setup(
     package_data={
         'klusta': ['*.txt', '*.prb'],
     },
-    install_requires=['setuptools'],
+    install_requires=[
+        'click',
+        'h5py',
+        'numpy',
+        'scipy',
+        # For pkg_resources:
+        'setuptools',
+        'six',
+        'tqdm',
+    ],
     entry_points={
         'console_scripts': [
             'klusta = klusta.launch:main'

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     package_data={
         'klusta': ['*.txt', '*.prb'],
     },
+    install_requires=['setuptools'],
     entry_points={
         'console_scripts': [
             'klusta = klusta.launch:main'


### PR DESCRIPTION
The dependencies should be part of the package metadata so that `pip install`, RPM dependency generators, and many  other things work as expected.

This includes and builds on https://github.com/kwikteam/klusta/pull/76, which added `setuptools` for `import pkg_resources`; to that, I have added `click`, `h5py`, `numpy`, `scipy`, `six`, and `tqdm`.

I chose *not* to add a hard dependency on [`klustakwik2`](https://pypi.org/project/klustakwik2), which is needed only for the `klusta.klustakwik.sparsify_features_masks()` API function. [Optional dependencies](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies) like this are a good fit for [Extras](https://peps.python.org/pep-0508/#extras), and adding one could be a good follow-up to this PR if development on this project picks back up at some point.