### PR TITLE
Stop using numpy type aliases that were deprecated in 1.20 and later removed

### DIFF
--- a/klusta/traces/detect.py
+++ b/klusta/traces/detect.py
@@ -355,8 +355,8 @@ class FloodFillDetector(object):
         self._channels_per_group = channels_per_group
 
     def __call__(self, weak_crossings=None, strong_crossings=None):
-        weak_crossings = np.asarray(weak_crossings, np.bool)
-        strong_crossings = np.asarray(strong_crossings, np.bool)
+        weak_crossings = np.asarray(weak_crossings, np.bool_)
+        strong_crossings = np.asarray(strong_crossings, np.bool_)
         all_channels = sorted([item for sublist
                               in self._channels_per_group.values()
                               for item in sublist])

--- a/klusta/traces/spikedetekt.py
+++ b/klusta/traces/spikedetekt.py
@@ -69,7 +69,7 @@ def _split_spikes(groups, idx=None, **arrs):
 
 
 def _array_list(arrs):
-    out = np.empty((len(arrs),), dtype=np.object)
+    out = np.empty((len(arrs),), dtype=object)
     out[:] = arrs
     return out
 
@@ -385,10 +385,10 @@ class SpikeDetekt(object):
         # groups).
         waveforms = _array_list(waveforms)
         assert waveforms.shape == (n_spikes,)
-        assert waveforms.dtype == np.object
+        assert waveforms.dtype == object
 
         masks = _array_list(masks)
-        assert masks.dtype == np.object
+        assert masks.dtype == object
         assert masks.shape == (n_spikes,)
 
         # Reorder the spikes.

--- a/klusta/traces/spikedetekt.py
+++ b/klusta/traces/spikedetekt.py
@@ -49,7 +49,7 @@ def _split_spikes(groups, idx=None, **arrs):
               }
     groups = np.asarray(groups)
     if idx is not None:
-        assert idx.dtype == np.bool
+        assert idx.dtype in (bool, np.bool_)
         n_spikes_chunk = np.sum(idx)
         # First, remove the overlapping bands.
         groups = groups[idx]

--- a/klusta/traces/store.py
+++ b/klusta/traces/store.py
@@ -97,7 +97,7 @@ class ArrayStore(object):
             dtype = data.dtype
             if not data.size:
                 return
-            assert dtype != np.object
+            assert dtype != object
             np.save(path, data)
         # debug("Store {}.".format(path))
 

--- a/klusta/traces/tests/test_spikedetekt.py
+++ b/klusta/traces/tests/test_spikedetekt.py
@@ -49,7 +49,7 @@ def test_split_spikes():
     groups = np.zeros(10, dtype=int)
     groups[1::2] = 1
 
-    idx = np.ones(10, dtype=np.bool)
+    idx = np.ones(10, dtype=np.bool_)
     idx[0] = False
     idx[-1] = False
 

--- a/klusta/traces/tests/test_spikedetekt.py
+++ b/klusta/traces/tests/test_spikedetekt.py
@@ -46,7 +46,7 @@ def test_relative_channels():
 
 
 def test_split_spikes():
-    groups = np.zeros(10, dtype=np.int)
+    groups = np.zeros(10, dtype=int)
     groups[1::2] = 1
 
     idx = np.ones(10, dtype=np.bool)

--- a/klusta/traces/waveform.py
+++ b/klusta/traces/waveform.py
@@ -110,7 +110,7 @@ class WaveformExtractor(object):
         s_min = comp.s_min
 
         # Binary mask. shape: (nc,)
-        masks_bin = np.zeros(nc, dtype=np.bool)
+        masks_bin = np.zeros(nc, dtype=np.bool_)
         masks_bin[np.unique(comp_ch)] = 1
 
         # Find the peaks (relative to the start of the chunk). shape: (nc,)

--- a/klusta/utils.py
+++ b/klusta/utils.py
@@ -75,7 +75,7 @@ def _index_of(arr, lookup):
     # values
     lookup = np.asarray(lookup, dtype=np.int32)
     m = (lookup.max() if len(lookup) else 0) + 1
-    tmp = np.zeros(m + 1, dtype=np.int)
+    tmp = np.zeros(m + 1, dtype=int)
     # Ensure that -1 values are kept.
     tmp[-1] = -1
     if len(lookup):


### PR DESCRIPTION
The types `np.object` and `np.int` were just aliases for the built-in `object` and `int`, respectively, so use those instead.

In older numpy releases, `numpy.bool` was the same as Python `bool`. This was deprecated in 1.20 and later removed for 1.x, then the name `numpy.bool` was reintroduced in numpy 2.x as an alias for `numpy.bool_`, a Boolean value stored as a byte. By using `numpy.bool_` everywhere, we get the same data type on all Python versions.

Fixes:

```
E           AttributeError: module 'numpy' has no attribute 'object'.
E           `np.object` was a deprecated alias for the builtin `object`. To avoid this error in existing code, use `object` by itself. Doing this will not modify any behavior and is safe.
E           The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
E               https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

```
E           AttributeError: module 'numpy' has no attribute 'int'.
E           `np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
E           The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
E               https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

(Only on numpy 1.x; `numpy.bool` works on 2.x, but with a different meaning):
```
E           AttributeError: module 'numpy' has no attribute 'bool'.
E           `np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted
 the numpy scalar type, use `np.bool_` here.
E           The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
E               https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'bool_'?
```